### PR TITLE
Fix chunk reader cache bug

### DIFF
--- a/cmd/dump_index/s3reader.go
+++ b/cmd/dump_index/s3reader.go
@@ -188,7 +188,7 @@ func (r *OptimizedS3Reader) ReadAtWithContext(ctx context.Context, p []byte, off
 			pieceData, exists := r.cache[cacheKey]
 			r.mu.RUnlock()
 			if !exists {
-				pieceData, found := r.readChunkPieceFromLocalCache(pieceStart, pieceLength)
+				pieceData, found = r.readChunkPieceFromLocalCache(pieceStart, pieceLength)
 				if !found {
 					rangeHeader := fmt.Sprintf("bytes=%d-%d", pieceStart, pieceStart+pieceLength-1)
 					resp, err := r.client.GetObject(ctx, &s3.GetObjectInput{


### PR DESCRIPTION
## Summary
- fix reassignment bug in chunk cache path

## Testing
- `go vet ./...` *(fails: missing go.sum entries)*
- `go mod tidy` *(fails to download modules: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846e8ad3f54832f89b53acc7b30195e