### PR TITLE
Fix chunk length handling and chunk table output

### DIFF
--- a/cmd/dump_index/main.go
+++ b/cmd/dump_index/main.go
@@ -179,7 +179,7 @@ func dumpSeries(cfg Config) error {
 	}
 
 	if cfg.DumpChunkTable {
-		return outputChunkTable(chunkInfos)
+		return outputChunkTable(chunkInfos, s3Client, bucket, tenant, blockID, cfg)
 	}
 
 	chunksByFile := make(map[int][]ChunkInfo)


### PR DESCRIPTION
## Summary
- parse chunk references according to BlockChunkRef spec
- determine chunk length by reading chunk headers
- update chunk table generation to fetch chunk lengths from S3

## Testing
- `go vet ./...` *(fails: `no packages to vet`)*

------
https://chatgpt.com/codex/tasks/task_e_6846ee9a6348832fb19d02f9c796b5a8