### PR TITLE
Stream results directly to file

### DIFF
--- a/cmd/dump_index/output.go
+++ b/cmd/dump_index/output.go
@@ -31,6 +31,131 @@ func buildOutputPath(cfg Config, bucket, tenant, blockID, ext string) (string, e
 	return filepath.Join(dir, name+"."+ext), nil
 }
 
+type streamWriter interface {
+	WritePoints([]SeriesPoint) error
+	Close() error
+}
+
+func newStreamWriter(cfg Config, bucket, tenant, blockID string) (streamWriter, string, error) {
+	ext := cfg.OutputFormat
+	if ext == "prometheus" {
+		ext = "prom"
+	}
+
+	outputPath, err := buildOutputPath(cfg, bucket, tenant, blockID, ext)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to build output path: %w", err)
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create output file: %w", err)
+	}
+
+	switch cfg.OutputFormat {
+	case "csv":
+		w := csv.NewWriter(f)
+		if err := w.Write([]string{"series_labels", "timestamp", "value"}); err != nil {
+			f.Close()
+			return nil, "", fmt.Errorf("failed to write CSV header: %w", err)
+		}
+		return &csvStreamWriter{f: f, w: w}, outputPath, nil
+	case "json":
+		if _, err := fmt.Fprintln(f, "["); err != nil {
+			f.Close()
+			return nil, "", err
+		}
+		return &jsonStreamWriter{f: f, first: true}, outputPath, nil
+	case "prometheus":
+		return &promStreamWriter{f: f}, outputPath, nil
+	default:
+		f.Close()
+		return nil, "", fmt.Errorf("unsupported output format: %s", cfg.OutputFormat)
+	}
+}
+
+type csvStreamWriter struct {
+	f *os.File
+	w *csv.Writer
+}
+
+func (c *csvStreamWriter) WritePoints(points []SeriesPoint) error {
+	for _, p := range points {
+		record := []string{
+			p.SeriesLabels,
+			strconv.FormatInt(p.Timestamp, 10),
+			strconv.FormatFloat(p.Value, 'f', -1, 64),
+		}
+		if err := c.w.Write(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *csvStreamWriter) Close() error {
+	c.w.Flush()
+	err1 := c.w.Error()
+	err2 := c.f.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+type jsonStreamWriter struct {
+	f     *os.File
+	first bool
+}
+
+func (j *jsonStreamWriter) WritePoints(points []SeriesPoint) error {
+	for _, p := range points {
+		if j.first {
+			j.first = false
+		} else {
+			if _, err := fmt.Fprintln(j.f, ","); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(j.f, "  {\"series\": %q, \"timestamp\": %d, \"value\": %g}",
+			p.SeriesLabels, p.Timestamp, p.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *jsonStreamWriter) Close() error {
+	if j.first {
+		if _, err := fmt.Fprintln(j.f, "[]"); err != nil {
+			j.f.Close()
+			return err
+		}
+		return j.f.Close()
+	}
+	if _, err := fmt.Fprintln(j.f, "\n]"); err != nil {
+		j.f.Close()
+		return err
+	}
+	return j.f.Close()
+}
+
+type promStreamWriter struct {
+	f *os.File
+}
+
+func (p *promStreamWriter) WritePoints(points []SeriesPoint) error {
+	for _, pt := range points {
+		ts := float64(pt.Timestamp) / 1000.0
+		if _, err := fmt.Fprintf(p.f, "%s %g %g\n", pt.SeriesLabels, pt.Value, ts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *promStreamWriter) Close() error { return p.f.Close() }
+
 func outputResults(points []SeriesPoint, cfg Config, bucket, tenant, blockID string) error {
 	ext := cfg.OutputFormat
 	if ext == "prometheus" {


### PR DESCRIPTION
## Summary
- stream output directly to file using new `streamWriter`
- write points as we process chunks
- simplify main dump function to use streaming writer

## Testing
- `gofmt -w cmd/dump_index/output.go cmd/dump_index/chunks.go cmd/dump_index/main.go`
- `go build ./cmd/dump_index` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_6847053c37d0832fa5a11ee3ea6d79bf