### PR TITLE
Fix dump_index compile issues

### DIFF
--- a/cmd/dump_index/local.go
+++ b/cmd/dump_index/local.go
@@ -62,7 +62,7 @@ func dumpSeriesLocal(cfg Config, blockDir, bucket, tenant, blockID string) error
 			if cfg.EndTime > 0 && meta.MinTime > cfg.EndTime {
 				continue
 			}
-			chk, _, err := chunkr.ChunkOrIterable(meta)
+			chk, err := chunkr.Chunk(meta)
 			if err != nil {
 				return fmt.Errorf("chunk read: %w", err)
 			}
@@ -99,7 +99,7 @@ func dumpSeriesLocal(cfg Config, blockDir, bucket, tenant, blockID string) error
 	return outputResults(allPoints, cfg, bucket, tenant, blockID)
 }
 
-func postingsFromConfig(idx index.Reader, cfg Config) (index.Postings, error) {
+func postingsFromConfig(idx tsdb.IndexReader, cfg Config) (index.Postings, error) {
 	var (
 		p   index.Postings
 		err error


### PR DESCRIPTION
## Summary
- fix compile errors in `dump_index` tool when using tsdb v0.47

## Testing
- `go vet ./...` *(fails: no packages)*
- `go vet ./cmd/dump_index/...` *(fails: go mod tidy needed but network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68474bed4918832f9e89f40b101ed4d3