### PR TITLE
Remove force index parallel and switch threshold

### DIFF
--- a/cmd/dump_index/types.go
+++ b/cmd/dump_index/types.go
@@ -6,26 +6,24 @@ import (
 )
 
 type Config struct {
-	BlockPath          string
-	MetricName         string
-	LabelKey           string
-	LabelValue         string
-	AWSRegion          string
-	AWSProfile         string
-	Debug              bool
-	CheckRegion        bool
-	ForceIndexParallel bool
-	ChunkWorkers       int
-	ChunkFileWorkers   int
-	ChunkTimeout       int
-	WorkingDir         string
-	StartTime          int64
-	EndTime            int64
-	OutputFormat       string
-	SwitchThreshold    float64
-	DumpChunkTable     bool
-	OutputFilename     string
-	OutputLabels       string
+	BlockPath        string
+	MetricName       string
+	LabelKey         string
+	LabelValue       string
+	AWSRegion        string
+	AWSProfile       string
+	Debug            bool
+	CheckRegion      bool
+	ChunkWorkers     int
+	ChunkFileWorkers int
+	ChunkTimeout     int
+	WorkingDir       string
+	StartTime        int64
+	EndTime          int64
+	OutputFormat     string
+	DumpChunkTable   bool
+	OutputFilename   string
+	OutputLabels     string
 }
 
 type SeriesPoint struct {


### PR DESCRIPTION
## Summary
- remove `force-index-parallel` and `switch-threshold` flags
- rely solely on the piece-based 64MB caching
- drop unused fields

## Testing
- `go mod tidy` *(fails: Forbidden)*
- `go build` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_68475216851c832fa8412765b57e1dde