### PR TITLE
Reintroduce force-index-parallel flag

### DIFF
--- a/cmd/dump_index/types.go
+++ b/cmd/dump_index/types.go
@@ -6,24 +6,25 @@ import (
 )
 
 type Config struct {
-	BlockPath        string
-	MetricName       string
-	LabelKey         string
-	LabelValue       string
-	AWSRegion        string
-	AWSProfile       string
-	Debug            bool
-	CheckRegion      bool
-	ChunkWorkers     int
-	ChunkFileWorkers int
-	ChunkTimeout     int
-	WorkingDir       string
-	StartTime        int64
-	EndTime          int64
-	OutputFormat     string
-	DumpChunkTable   bool
-	OutputFilename   string
-	OutputLabels     string
+	BlockPath          string
+	MetricName         string
+	LabelKey           string
+	LabelValue         string
+	AWSRegion          string
+	AWSProfile         string
+	Debug              bool
+	CheckRegion        bool
+	ForceIndexParallel bool
+	ChunkWorkers       int
+	ChunkFileWorkers   int
+	ChunkTimeout       int
+	WorkingDir         string
+	StartTime          int64
+	EndTime            int64
+	OutputFormat       string
+	DumpChunkTable     bool
+	OutputFilename     string
+	OutputLabels       string
 }
 
 type SeriesPoint struct {


### PR DESCRIPTION
## Summary
- add `ForceIndexParallel` option to `Config`
- expose `--force-index-parallel` CLI flag
- download the index in parallel when the flag is set

## Testing
- `go build .` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_68475dd27ca4832f8298f28a18c22618