### PR TITLE
Fix meta.json region detection

### DIFF
--- a/cmd/dump_index/chunks.go
+++ b/cmd/dump_index/chunks.go
@@ -119,7 +119,7 @@ func outputChunkTable(chunkInfos []ChunkInfo, s3Client *s3.Client, bucket, tenan
 			chunkCacheDir = cfg.WorkingDir
 		}
 
-		reader, err := NewOptimizedS3ReaderWithCache(s3Client, bucket, chunksKey, cfg.Debug, chunkCacheDir, "chunks")
+		reader, err := NewOptimizedS3ReaderWithCache(s3Client, bucket, chunksKey, cfg.Debug, chunkCacheDir, "chunks", cfg.AWSProfile)
 		if err != nil {
 			return fmt.Errorf("failed to create chunks reader for file %06d: %w", fileNum, err)
 		}


### PR DESCRIPTION
## Summary
- add general region detection for meta.json and other files
- eliminate manual retry logic in `dump_index`
- embed auto-region detection into `s3reader`

## Testing
- `go vet ./...` *(fails: no packages)*
- `go build ./cmd/dump_index` *(fails: module not in root)*

------
https://chatgpt.com/codex/tasks/task_e_68477437e094832fb81b85b6b08ccf12