### PR TITLE
Fix compile issues in dump_index tool

### DIFF
--- a/cmd/dump_index/main.go
+++ b/cmd/dump_index/main.go
@@ -9,11 +9,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
-	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/prometheus/prometheus/tsdb/index"
@@ -111,7 +108,7 @@ func dumpSeries(cfg Config) error {
 			fmt.Fprintf(os.Stderr, "meta.json missing locally, downloading...\n")
 		}
 
-		s3Client, err := downloadMetaFile(s3Client, bucket, tenant, blockID, metaPath, cfg.AWSProfile, cfg.Debug)
+		s3Client, err = downloadMetaFile(s3Client, bucket, tenant, blockID, metaPath, cfg.AWSProfile, cfg.Debug)
 		if err == nil {
 			metaExists = true
 			if cfg.Debug {


### PR DESCRIPTION
## Summary
- remove unused imports in `cmd/dump_index/main.go`
- fix redeclared variable assignment when downloading meta file
- ensure `resp` is declared before use in S3 reader
- clean up context usage in S3 download routines

## Testing
- `go build ./cmd/dump_index` *(fails: main module does not contain package)*
- `cd cmd/dump_index && go build .` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_684780f9ff90832fb5d66d8b41eb3f83