### PR TITLE
Use piece-based readers for local blocks

### DIFF
--- a/cmd/dump_index/local.go
+++ b/cmd/dump_index/local.go
@@ -1,100 +1,120 @@
 package main
 
 import (
+	"encoding/csv"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 )
 
 func dumpSeriesLocal(cfg Config, blockDir, bucket, tenant, blockID string) error {
 	if cfg.Debug {
-		fmt.Fprintf(os.Stderr, "Reading local block at %s\n", blockDir)
-	}
-	blk, err := tsdb.OpenBlock(log.NewNopLogger(), blockDir, chunkenc.NewPool())
-	if err != nil {
-		return fmt.Errorf("open local block: %w", err)
-	}
-	defer blk.Close()
-
-	idxr, err := blk.Index()
-	if err != nil {
-		return fmt.Errorf("block.Index: %w", err)
-	}
-	defer idxr.Close()
-
-	chunkr, err := blk.Chunks()
-	if err != nil {
-		return fmt.Errorf("block.Chunks: %w", err)
-	}
-	defer chunkr.Close()
-
-	postings, err := postingsFromConfig(idxr, cfg)
-	if err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, "Reading local block from pieces at %s\n", blockDir)
 	}
 
-	var builder labels.ScratchBuilder
-	var metas []chunks.Meta
-	var it chunkenc.Iterator
+	indexPath := filepath.Join(blockDir, "index")
+	indexReader, err := NewLocalPieceReader(indexPath, "index", cfg.Debug)
+	if err != nil {
+		return fmt.Errorf("failed to create local index reader: %w", err)
+	}
+
+	idx, err := index.NewReader(indexReader)
+	if err != nil {
+		return fmt.Errorf("failed to open index reader: %w", err)
+	}
+	defer idx.Close()
+
+	fmt.Fprintf(os.Stderr, "Reading chunk locations from index...\n")
+	chunkInfos, err := getChunkReferences(*idx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to get chunk references: %w", err)
+	}
+
+	chunkFileStats := make(map[int]int)
+	for _, ci := range chunkInfos {
+		chunkFileStats[ci.ChunkFileNum]++
+	}
+
+	fmt.Fprintf(os.Stderr, "Found %d chunks distributed across chunk files:\n", len(chunkInfos))
+	for fileNum, count := range chunkFileStats {
+		fmt.Fprintf(os.Stderr, "  chunks/%06d: %d chunks\n", fileNum, count)
+	}
+
+	if cfg.DumpChunkTable {
+		// Build and output chunk table using local pieces
+		return outputChunkTableLocal(chunkInfos, blockDir, bucket, tenant, blockID, cfg)
+	}
+
+	chunksByFile := make(map[int][]ChunkInfo)
+	for _, ci := range chunkInfos {
+		chunksByFile[ci.ChunkFileNum] = append(chunksByFile[ci.ChunkFileNum], ci)
+	}
+
+	type chunkFileJob struct {
+		fileNum    int
+		fileChunks []ChunkInfo
+	}
+
+	fileJobs := make(chan chunkFileJob)
+	results := make(chan []SeriesPoint)
+	errCh := make(chan error, len(chunksByFile))
+
+	var wg sync.WaitGroup
+	for w := 0; w < cfg.ChunkFileWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range fileJobs {
+				chunkDir := filepath.Join(blockDir, "chunks", fmt.Sprintf("%06d", job.fileNum))
+				chunkFileName := fmt.Sprintf("%s/chunks/%06d", blockID, job.fileNum)
+
+				reader, err := NewLocalPieceReader(chunkDir, "chunks", cfg.Debug)
+				if err != nil {
+					errCh <- fmt.Errorf("failed to create local chunks reader for file %06d: %w", job.fileNum, err)
+					continue
+				}
+
+				fmt.Fprintf(os.Stderr, "Reading time series data from %s (%d chunks)...\n", chunkFileName, len(job.fileChunks))
+				points, err := readChunkData(reader, job.fileChunks, cfg, chunkFileName)
+				if err != nil {
+					errCh <- fmt.Errorf("failed to read chunk data from %s: %w", chunkFileName, err)
+					continue
+				}
+
+				results <- points
+			}
+		}()
+	}
+
+	go func() {
+		for fileNum, fileChunks := range chunksByFile {
+			fileJobs <- chunkFileJob{fileNum: fileNum, fileChunks: fileChunks}
+		}
+		close(fileJobs)
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
 
 	var allPoints []SeriesPoint
-
-	for postings.Next() {
-		seriesID := postings.At()
-		builder.Reset()
-		metas = metas[:0]
-		if err := idxr.Series(seriesID, &builder, &metas); err != nil {
-			return fmt.Errorf("series %d: %w", seriesID, err)
-		}
-		lbls := builder.Labels()
-		labelsStr := lbls.String()
-		for _, meta := range metas {
-			if cfg.StartTime > 0 && meta.MaxTime < cfg.StartTime {
-				continue
-			}
-			if cfg.EndTime > 0 && meta.MinTime > cfg.EndTime {
-				continue
-			}
-			chk, err := chunkr.Chunk(meta)
-			if err != nil {
-				return fmt.Errorf("chunk read: %w", err)
-			}
-			if chk == nil {
-				continue
-			}
-			it = chk.Iterator(it)
-			for it.Next() == chunkenc.ValFloat {
-				ts, v := it.At()
-				if cfg.StartTime > 0 && ts < cfg.StartTime {
-					continue
-				}
-				if cfg.EndTime > 0 && ts > cfg.EndTime {
-					continue
-				}
-				allPoints = append(allPoints, SeriesPoint{
-					SeriesLabels: labelsStr,
-					Labels:       lbls,
-					Timestamp:    ts,
-					Value:        v,
-				})
-			}
-			if it.Err() != nil {
-				return fmt.Errorf("iterator error: %w", it.Err())
-			}
-		}
-	}
-	if err := postings.Err(); err != nil {
-		return err
+	for pts := range results {
+		allPoints = append(allPoints, pts...)
 	}
 
-	fmt.Fprintf(os.Stderr, "Extracted %d data points from local block\n", len(allPoints))
+	close(errCh)
+	if len(errCh) > 0 {
+		return <-errCh
+	}
+
+	fmt.Fprintf(os.Stderr, "Extracted %d data points from %d chunk files\n", len(allPoints), len(chunksByFile))
 
 	return outputResults(allPoints, cfg, bucket, tenant, blockID)
 }
@@ -124,4 +144,57 @@ func postingsFromConfig(idx tsdb.IndexReader, cfg Config) (index.Postings, error
 
 func localBlockPath(cfg Config, bucket, tenant, blockID string) string {
 	return filepath.Join(cfg.WorkingDir, bucket, tenant, blockID)
+}
+
+func outputChunkTableLocal(chunkInfos []ChunkInfo, blockDir, bucket, tenant, blockID string, cfg Config) error {
+	outputPath, err := buildOutputPath(cfg, bucket, tenant, blockID, "csv")
+	if err != nil {
+		return fmt.Errorf("failed to build output path: %w", err)
+	}
+
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	if err := writer.Write([]string{"series_labels", "chunk_file", "chunk_offset", "chunk_length", "min_time", "max_time"}); err != nil {
+		return fmt.Errorf("failed to write chunk table header: %w", err)
+	}
+
+	chunksByFile := make(map[int][]ChunkInfo)
+	for _, ci := range chunkInfos {
+		chunksByFile[ci.ChunkFileNum] = append(chunksByFile[ci.ChunkFileNum], ci)
+	}
+
+	for fileNum, fileChunks := range chunksByFile {
+		chunkDir := filepath.Join(blockDir, "chunks", fmt.Sprintf("%06d", fileNum))
+		reader, err := NewLocalPieceReader(chunkDir, "chunks", cfg.Debug)
+		if err != nil {
+			return fmt.Errorf("failed to create chunks reader for file %06d: %w", fileNum, err)
+		}
+		for _, ci := range fileChunks {
+			_, length, _, err := readRawChunk(reader, ci.ChunkOffset)
+			if err != nil {
+				return fmt.Errorf("failed to read chunk at offset %d in file %06d: %w", ci.ChunkOffset, fileNum, err)
+			}
+			record := []string{
+				ci.SeriesLabel.String(),
+				fmt.Sprintf("%06d", ci.ChunkFileNum),
+				strconv.FormatUint(ci.ChunkOffset, 10),
+				strconv.FormatUint(uint64(length), 10),
+				strconv.FormatInt(ci.ChunkRef.MinTime, 10),
+				strconv.FormatInt(ci.ChunkRef.MaxTime, 10),
+			}
+			if err := writer.Write(record); err != nil {
+				return fmt.Errorf("failed to write chunk table record: %w", err)
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Dumped chunk table with %d entries to %s\n", len(chunkInfos), outputPath)
+	return nil
 }

--- a/cmd/dump_index/localreader.go
+++ b/cmd/dump_index/localreader.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// LocalPieceReader reads file data stored as pieces on disk.
+type LocalPieceReader struct {
+	dir      string
+	size     int64
+	fileType string
+	debug    bool
+	cache    map[string][]byte
+	mu       sync.RWMutex
+	data     []byte
+	useFull  bool
+}
+
+func NewLocalPieceReader(path string, fileType string, debug bool) (*LocalPieceReader, error) {
+	info, err := os.Stat(path)
+	if err == nil && !info.IsDir() {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		return &LocalPieceReader{
+			dir:      filepath.Dir(path),
+			size:     info.Size(),
+			fileType: fileType,
+			debug:    debug,
+			data:     b,
+			useFull:  true,
+		}, nil
+	}
+
+	size, err := computeSizeFromPieces(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LocalPieceReader{
+		dir:      path,
+		size:     size,
+		fileType: fileType,
+		debug:    debug,
+		cache:    make(map[string][]byte),
+	}, nil
+}
+
+func computeSizeFromPieces(dir string) (int64, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, err
+	}
+	var max int64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		var off, length int64
+		if _, err := fmt.Sscanf(e.Name(), "%d_%d.bin", &off, &length); err == nil {
+			if off+length > max {
+				max = off + length
+			}
+		}
+	}
+	return max, nil
+}
+
+func (r *LocalPieceReader) pieceSize() int64 {
+	if r.fileType == "index" {
+		return indexPieceSize
+	}
+	return chunkPieceSize
+}
+
+func (r *LocalPieceReader) loadPiece(start, length int64) ([]byte, error) {
+	key := fmt.Sprintf("%d_%d", start, length)
+	r.mu.RLock()
+	if data, ok := r.cache[key]; ok {
+		r.mu.RUnlock()
+		return data, nil
+	}
+	r.mu.RUnlock()
+
+	file := filepath.Join(r.dir, fmt.Sprintf("%d_%d.bin", start, length))
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	r.cache[key] = data
+	r.mu.Unlock()
+	return data, nil
+}
+
+func (r *LocalPieceReader) ReadAt(p []byte, off int64) (int, error) {
+	if off >= r.size {
+		return 0, io.EOF
+	}
+	end := off + int64(len(p)) - 1
+	if end >= r.size {
+		end = r.size - 1
+	}
+
+	if r.useFull {
+		n := copy(p, r.data[off:end+1])
+		if n < len(p) {
+			return n, io.EOF
+		}
+		return n, nil
+	}
+
+	pieceSize := r.pieceSize()
+	bytesRead := 0
+	cur := off
+	for cur <= end {
+		pieceStart := (cur / pieceSize) * pieceSize
+		pieceLen := pieceSize
+		if pieceStart+pieceLen > r.size {
+			pieceLen = r.size - pieceStart
+		}
+		data, err := r.loadPiece(pieceStart, pieceLen)
+		if err != nil {
+			return bytesRead, err
+		}
+		copyStart := cur - pieceStart
+		copyLen := pieceLen - copyStart
+		if cur+copyLen-1 > end {
+			copyLen = end - cur + 1
+		}
+		if copyStart+copyLen > int64(len(data)) {
+			copyLen = int64(len(data)) - copyStart
+		}
+		copy(p[bytesRead:bytesRead+int(copyLen)], data[copyStart:copyStart+copyLen])
+		bytesRead += int(copyLen)
+		cur += copyLen
+	}
+	if bytesRead < len(p) {
+		return bytesRead, io.EOF
+	}
+	return bytesRead, nil
+}
+
+func (r *LocalPieceReader) Len() int { return int(r.size) }
+
+func (r *LocalPieceReader) Range(start, end int) []byte {
+	if start < 0 || int64(end) > r.size || start >= end {
+		return nil
+	}
+	buf := make([]byte, end-start)
+	n, _ := r.ReadAt(buf, int64(start))
+	return buf[:n]
+}
+
+func (r *LocalPieceReader) Sub(start, end int) index.ByteSlice {
+	if start < 0 || int64(end) > r.size || start >= end {
+		return nil
+	}
+	data := r.Range(start, end)
+	return &simpleByteSlice{data: data}
+}
+
+func (r *LocalPieceReader) Size() int64 { return r.size }


### PR DESCRIPTION
## Summary
- add `LocalPieceReader` to read TSDB block pieces from disk
- support DataReader interface for chunk processing
- rework local block path to use piece-based logic instead of `tsdb.OpenBlock`

## Testing
- `go build ./cmd/dump_index` *(fails: missing go.sum entries due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6847938c5414832f9501a6acb5c53a38