### PR TITLE
Fix missing import in localreader

### DIFF
--- a/cmd/dump_index/localreader.go
+++ b/cmd/dump_index/localreader.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/prometheus/prometheus/tsdb/index"
 )
 
 // LocalPieceReader reads file data stored as pieces on disk.


### PR DESCRIPTION
## Summary
- add missing `index` package import to `localreader.go`

## Testing
- `go build` *(fails: missing go.sum entry due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68483e6089f8832fa3bb268281ebd9f3